### PR TITLE
Allow mysql compatible packages

### DIFF
--- a/attributes/server_debian.rb
+++ b/attributes/server_debian.rb
@@ -5,7 +5,7 @@ when 'debian'
   # Keep in this namespace for backwards compat
   default['mysql']['data_dir'] = '/var/lib/mysql'
 
-  default['mysql']['server']['packages'] = %w{ mysql-server apparmor-utils }
+  default['mysql']['server']['packages'] = %w{ mysql-common mysql-server apparmor-utils }
   default['mysql']['server']['slow_query_log']       = 1
   default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
 

--- a/attributes/server_rhel.rb
+++ b/attributes/server_rhel.rb
@@ -15,6 +15,10 @@ when 'rhel'
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['slow_query_log']       = 1
     default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
+  when 7
+    default['mysql']['server']['packages'] = ['mysql-server']
+    default['mysql']['server']['slow_query_log']       = 1
+    default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
   when 2013 # amazon linux
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['slow_query_log']       = 1

--- a/attributes/server_rhel.rb
+++ b/attributes/server_rhel.rb
@@ -11,11 +11,7 @@ when 'rhel'
   when 5
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['log_slow_queries']     = '/var/log/mysql/slow.log'
-  when 6
-    default['mysql']['server']['packages'] = ['mysql-server']
-    default['mysql']['server']['slow_query_log']       = 1
-    default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'
-  when 7
+  when 6, 7
     default['mysql']['server']['packages'] = ['mysql-server']
     default['mysql']['server']['slow_query_log']       = 1
     default['mysql']['server']['slow_query_log_file']  = '/var/log/mysql/slow.log'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module Opscode
       def install_grants_cmd
         str = '/usr/bin/mysql'
         str << ' -u root '
-        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " -p#{node['mysql']['server_root_password']} < /etc/mysql_grants.sql"
+        node['mysql']['server_root_password'].empty? ? str << ' < /etc/mysql_grants.sql' : str << " --password=#{node['mysql']['server_root_password']} < /etc/mysql_grants.sql"
       end
     end
   end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -62,6 +62,8 @@ bash 'move mysql data to datadir' do
   code <<-EOH
   /usr/sbin/service mysql stop &&
   mv /var/lib/mysql/* #{node['mysql']['data_dir']} &&
+  rm -rf /var/lib/mysql &&
+  ln -s #{node['mysql']['data_dir']} /var/lib/mysql &&
   /usr/sbin/service mysql start
   EOH
   action :nothing

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -52,7 +52,7 @@ template '/etc/mysql/my.cnf' do
   mode '0644'
   notifies :install, 'package[mysql-server]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :restart, 'service[mysql]'
+  notifies :restart, 'service[mysql]', :immediately
 end
 
 # don't try this at home

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -153,5 +153,5 @@ service 'mysql' do
   service_name 'mysql'
   supports     :status => true, :restart => true, :reload => true
   action       [:enable, :start]
-  provider     Chef::Provider::Service::Upstart
+  provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -52,7 +52,7 @@ template '/etc/mysql/my.cnf' do
   mode '0644'
   notifies :install, 'package[mysql-server]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :reload, 'service[mysql]'
+  notifies :restart, 'service[mysql]'
 end
 
 # don't try this at home

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -153,4 +153,5 @@ service 'mysql' do
   service_name 'mysql'
   supports     :status => true, :restart => true, :reload => true
   action       [:enable, :start]
+  provider     Chef::Provider::Service::Upstart
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -24,14 +24,13 @@ end
 #----
 # Install software
 #----
-# Do not install the 'mysql-server' package here as it should be installed after
-# the my.cnf file is created. This is required in order to have the innodb log file
-# created with the correct size set in my.cnf. The :install action of
-# package[mysql-server] resource is notified by the template[/etc/mysql/my.cnf].
-#
+
+# look for the server package and skip now and install later.  
+# find the server package and use that to install.
+server_package = node['mysql']['server']['packages'].select{|p| p =~ /server/}.first
 node['mysql']['server']['packages'].each do |name|
   package name do
-    action name == 'mysql-server' ? :nothing : :install
+    action name == server_package ? :nothing : :install
   end
 end
 
@@ -50,9 +49,10 @@ template '/etc/mysql/my.cnf' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :install, 'package[mysql-server]', :immediately
+  notifies :install, "package[#{server_package}]", :immediately
   notifies :run, 'execute[/usr/bin/mysql_install_db]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
+  notifies :create, 'template[/etc/init/mysql.conf]', :immediately
   notifies :restart, 'service[mysql]', :immediately
 end
 
@@ -131,9 +131,12 @@ directory node['mysql']['data_dir'] do
   recursive true
 end
 
+# mysql  doesn't need the defaults file supplied.  Percona (and possibly others do)
+#defaults_file = !["mysql"].include?(node['mysql']['server']['packages']) ? "/etc/mysql/my.cnf": nil
 template '/etc/init/mysql.conf' do
   source 'init-mysql.conf.erb'
-  only_if { node['platform_family'] == 'ubuntu' }
+  only_if { node['platform_family'] == 'debian' }
+  variables(:defaults_file=>"/etc/mysql/my.cnf")
 end
 
 template '/etc/apparmor.d/usr.sbin.mysqld' do
@@ -150,7 +153,7 @@ end
 
 
 service 'mysql' do
-  service_name 'mysql'
+  service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
   action       [:enable, :start]
   provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'

--- a/recipes/_server_rhel.rb
+++ b/recipes/_server_rhel.rb
@@ -33,7 +33,7 @@ template 'initial-my.cnf' do
   mode '0644'
   notifies :run, 'execute[/usr/bin/mysql_install_db]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :start, 'service[mysql-start]', :immediately
+  notifies :restart, 'service[mysql-start]', :immediately
 end
 
 # The /usr/bin/mysql_install_db command initializes the MySQL data directory and creates the system if they don't

--- a/recipes/_server_rhel.rb
+++ b/recipes/_server_rhel.rb
@@ -31,7 +31,13 @@ template 'initial-my.cnf' do
   owner 'root'
   group 'root'
   mode '0644'
+  notifies :run, 'execute[/usr/bin/mysql_install_db]', :immediately
   notifies :start, 'service[mysql-start]', :immediately
+end
+
+execute '/usr/bin/mysql_install_db' do
+  action :nothing
+  creates "#{node['mysql']['data_dir']}/mysql/user.frm"
 end
 
 # hax
@@ -40,11 +46,6 @@ service 'mysql-start' do
   action :nothing
 end
 
-execute '/usr/bin/mysql_install_db' do
-  action :run
-  creates '/var/lib/mysql/user.frm'
-  only_if { node['platform_version'].to_i < 6 }
-end
 
 cmd = assign_root_password_cmd
 execute 'assign-root-password' do

--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -20,10 +20,11 @@ pre-start script
     [ -r $HOME/my.cnf ]
     [ -d /var/run/mysqld ] || install -m 755 -o mysql -g root -d /var/run/mysqld
     /lib/init/apparmor-profile-load usr.sbin.mysqld
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] >/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
-exec /usr/sbin/mysqld
+exec /usr/sbin/mysqld --defaults-file=<%=@defaults_file%>
+<%#= "#{}--defaults-file=#{@defaults_file}" if @defaults_file %>
 
 post-start script
     for i in `seq 1 30` ; do


### PR DESCRIPTION
Allow cookbook to install mysql compatible package from wrapper cookbook.  compatible packages may be percona and mariadb, or community mysql.

We needed this to use the rs-mysql cookbook with other mysql compatible packages.
