### PR TITLE
Allow mysql compatible packages

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures mysql for client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.22'
+version           '4.0.21'
 recipe            'mysql', 'Includes the client recipe to configure a client'
 recipe            'mysql::client', 'Installs packages required for mysql clients using run_action magic'
 recipe            'mysql::server', 'Installs packages required for mysql servers w/o manual intervention'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures mysql for client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.20'
+version           '4.0.21'
 recipe            'mysql', 'Includes the client recipe to configure a client'
 recipe            'mysql::client', 'Installs packages required for mysql clients using run_action magic'
 recipe            'mysql::server', 'Installs packages required for mysql servers w/o manual intervention'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures mysql for client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.21'
+version           '4.0.20'
 recipe            'mysql', 'Includes the client recipe to configure a client'
 recipe            'mysql::client', 'Installs packages required for mysql clients using run_action magic'
 recipe            'mysql::server', 'Installs packages required for mysql servers w/o manual intervention'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures mysql for client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.21'
+version           '4.0.22'
 recipe            'mysql', 'Includes the client recipe to configure a client'
 recipe            'mysql::client', 'Installs packages required for mysql clients using run_action magic'
 recipe            'mysql::server', 'Installs packages required for mysql servers w/o manual intervention'

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -155,5 +155,5 @@ service 'mysql' do
   service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
   action       [:enable,:start]
-  #provider     service_provider
+  provider     service_provider
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -24,7 +24,12 @@ end
 #----
 # Install software
 #----
-
+# Do not install the 'mysql-server' package here as it should be installed after
+# the my.cnf file is created. This is required in order to have the innodb log file
+# created with the correct size set in my.cnf. The :install action of
+# package[mysql-server] resource is notified by the template[/etc/mysql/my.cnf].
+#
+# Support for mysql compatible packages:
 # look for the server package and skip now and install later.  
 # find the server package and use that to install.
 server_package = node['mysql']['server']['packages'].select{|p| p =~ /server/}.first

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -158,5 +158,5 @@ service 'mysql' do
   service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
   action       [:enable,:start]
-  provider     service_provider
+  #provider     service_provider
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -158,5 +158,5 @@ service 'mysql' do
   service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
   action       [:enable,:start]
-  #provider     service_provider
+  provider     service_provider
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -52,7 +52,6 @@ template '/etc/mysql/my.cnf' do
   notifies :install, "package[#{server_package}]", :immediately
   notifies :run, 'execute[/usr/bin/mysql_install_db]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
-  notifies :create, 'template[/etc/init/mysql.conf]', :immediately
   notifies :restart, 'service[mysql]', :immediately
 end
 
@@ -151,12 +150,10 @@ service 'apparmor-mysql' do
   supports :reload => true
 end
 
-service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
-  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
 
 service 'mysql' do
-  service_name node['mysql']['server']['service_name']
+  service_name 'mysql'
   supports     :status => true, :restart => true, :reload => true
-  action       [:enable,:start]
-  #provider     service_provider
+  action       [:enable, :start]
+  provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -151,10 +151,12 @@ service 'apparmor-mysql' do
   supports :reload => true
 end
 
+service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
+  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
 
 service 'mysql' do
   service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
-  action       [:enable, :start]
-  provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
+  action       [:enable,:start]
+  #provider     service_provider
 end

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -24,14 +24,13 @@ end
 #----
 # Install software
 #----
-# Do not install the 'mysql-server' package here as it should be installed after
-# the my.cnf file is created. This is required in order to have the innodb log file
-# created with the correct size set in my.cnf. The :install action of
-# package[mysql-server] resource is notified by the template[/etc/mysql/my.cnf].
-#
+
+# look for the server package and skip now and install later.  
+# find the server package and use that to install.
+server_package = node['mysql']['server']['packages'].select{|p| p =~ /server/}.first
 node['mysql']['server']['packages'].each do |name|
   package name do
-    action name == 'mysql-server' ? :nothing : :install
+    action name == server_package ? :nothing : :install
   end
 end
 
@@ -50,9 +49,10 @@ template '/etc/mysql/my.cnf' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :install, 'package[mysql-server]', :immediately
+  notifies :install, "package[#{server_package}]", :immediately
   notifies :run, 'execute[/usr/bin/mysql_install_db]', :immediately
   notifies :run, 'bash[move mysql data to datadir]', :immediately
+  notifies :create, 'template[/etc/init/mysql.conf]', :immediately
   notifies :restart, 'service[mysql]', :immediately
 end
 
@@ -131,9 +131,12 @@ directory node['mysql']['data_dir'] do
   recursive true
 end
 
+# mysql  doesn't need the defaults file supplied.  Percona (and possibly others do)
+#defaults_file = !["mysql"].include?(node['mysql']['server']['packages']) ? "/etc/mysql/my.cnf": nil
 template '/etc/init/mysql.conf' do
   source 'init-mysql.conf.erb'
-  only_if { node['platform_family'] == 'ubuntu' }
+  only_if { node['platform_family'] == 'debian' }
+  variables(:defaults_file=>"/etc/mysql/my.cnf")
 end
 
 template '/etc/apparmor.d/usr.sbin.mysqld' do
@@ -150,7 +153,7 @@ end
 
 
 service 'mysql' do
-  service_name 'mysql'
+  service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
   action       [:enable, :start]
   provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'

--- a/recipes/_server_debian.rb
+++ b/recipes/_server_debian.rb
@@ -151,12 +151,10 @@ service 'apparmor-mysql' do
   supports :reload => true
 end
 
-service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
-  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
 
 service 'mysql' do
   service_name node['mysql']['server']['service_name']
   supports     :status => true, :restart => true, :reload => true
-  action       [:enable,:start]
-  provider     service_provider
+  action       [:enable, :start]
+  provider     Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu'
 end

--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -20,10 +20,10 @@ pre-start script
     [ -r $HOME/my.cnf ]
     [ -d /var/run/mysqld ] || install -m 755 -o mysql -g root -d /var/run/mysqld
     /lib/init/apparmor-profile-load usr.sbin.mysqld
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] >/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
-exec /usr/sbin/mysqld
+exec /usr/sbin/mysqld --defaults-file=<%= @defaults_file %> 
 
 post-start script
     for i in `seq 1 30` ; do

--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -23,8 +23,7 @@ pre-start script
     LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
-exec /usr/sbin/mysqld --defaults-file=<%=@defaults_file%>
-<%#= "#{}--defaults-file=#{@defaults_file}" if @defaults_file %>
+exec /usr/sbin/mysqld --defaults-file=<%= @defaults_file %> 
 
 post-start script
     for i in `seq 1 30` ; do

--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -20,10 +20,11 @@ pre-start script
     [ -r $HOME/my.cnf ]
     [ -d /var/run/mysqld ] || install -m 755 -o mysql -g root -d /var/run/mysqld
     /lib/init/apparmor-profile-load usr.sbin.mysqld
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] >/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
-exec /usr/sbin/mysqld
+exec /usr/sbin/mysqld --defaults-file=<%=@defaults_file%>
+<%#= "#{}--defaults-file=#{@defaults_file}" if @defaults_file %>
 
 post-start script
     for i in `seq 1 30` ; do

--- a/templates/default/init-mysql.conf.erb
+++ b/templates/default/init-mysql.conf.erb
@@ -20,10 +20,10 @@ pre-start script
     [ -r $HOME/my.cnf ]
     [ -d /var/run/mysqld ] || install -m 755 -o mysql -g root -d /var/run/mysqld
     /lib/init/apparmor-profile-load usr.sbin.mysqld
-    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] %>/. | tail -n 1 | awk '{ exit ($4<4096) }'
+    LC_ALL=C BLOCKSIZE= df --portability <%= node['mysql']['data_dir'] >/. | tail -n 1 | awk '{ exit ($4<4096) }'
 end script
 
-exec /usr/sbin/mysqld --defaults-file=<%= @defaults_file %> 
+exec /usr/sbin/mysqld
 
 post-start script
     for i in `seq 1 30` ; do


### PR DESCRIPTION
Allow cookbook to install mysql compatible package from wrapper cookbook. compatible packages may be percona and mariadb, or community mysql.

We needed this to use the rs-mysql cookbook with other mysql compatible packages.
