### PR TITLE
[#117862313] Payv2 Statsd attempt (#2)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures mysql for client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.0.20'
+version           '4.0.21'
 recipe            'mysql', 'Includes the client recipe to configure a client'
 recipe            'mysql::client', 'Installs packages required for mysql clients using run_action magic'
 recipe            'mysql::server', 'Installs packages required for mysql servers w/o manual intervention'
@@ -25,7 +25,7 @@ supports 'suse'
 supports 'windows'
 
 depends 'openssl',         '~> 1.1'
-depends 'build-essential', '~> 1.4'
+depends 'build-essential', '~> 2.1'
 
 # wat
 suggests 'homebrew'

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-node.set['build_essential']['compiletime'] = true
+node.set['build-essential']['compile_time'] = true
 include_recipe 'build-essential::default'
 include_recipe 'mysql::client'
 


### PR DESCRIPTION
- Fix possible breaking change as described in:
  https://supermarket.chef.io/cookbooks/build-essential#changelog
  
  **Potentially Breaking Changes**
  - Dropped support for OSX 10.6
  - OSX no longer downloads OSX GCC and uses XCode CLI tools instead
  - build_essential -> build-essential in node attributes
  - compiletime -> compile_time in node attributes
  - Cookbook version 2.x no longer supports Chef 10.x
- 1.4.4 is 2+ years old so time to update
- This is a blocker because:
  - statsd requires nodejs
  - nodejs requires homebrew
  - homebrew requires build-essential (>= 2.1.2)
- TODO: Need to test this further but this unblocks me to implement statsd
